### PR TITLE
Fix fontconfig non-family defaults

### DIFF
--- a/font-config-info.c
+++ b/font-config-info.c
@@ -352,14 +352,14 @@ void PrintFontconfigDefaults() {
   PrintFontconfigPattern(match, 1);
 
   printf("Fontconfig (non-family defaults):\n");
-  FcPattern* query_without_family = FcPatternDuplicate(query);
-  FcPatternRemove(query_without_family, FC_FAMILY, 0);
-  FcPattern* defaults = FcFontRenderPrepare(NULL, query, query_without_family);
+  FcPattern* defaults = FcPatternDuplicate(query);
+  FcPatternDel(defaults, FC_FAMILY);
+  FcConfigSubstituteWithPat (NULL, defaults, query, FcMatchFont);
+
   PrintFontconfigPattern(defaults, 0);
 
   FcPatternDestroy(query);
   FcPatternDestroy(match);
-  FcPatternDestroy(query_without_family);
   FcPatternDestroy(defaults);
 }
 


### PR DESCRIPTION
Main problem was that FcPatternRemove was used instead of
FcPatternDel.  Remove only removes one value whereas we wanted
to remove all family values.

After that, if we where to add a dummy value for FC_FAMILY to
query_without_family, then the code would work.  The reason we
need to add this is that if the query_without_family does NOT
have any FC_FAMILY, then FcFontRenderPrepare will copy the first
value of FC_FAMILY from query to query_without_family.  We don't
want that.

Alternatively, we can call FcConfigSubstituteWithPat instead
of FcFontRenderPrepare as this does exactly what we want: run
configuration stanzas with target=pattern.
